### PR TITLE
Adds fallback paths support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,17 @@ module.exports = {
 }
 ```
 
+### Fallback paths
+
+A single alias may specify multiple paths. The first matching path resolves.
+
+```js
+// alias.config.js
+module.exports = {
+  'utils/*': ['src/utils/*', 'utils/*'],
+}
+```
+
 ## Integrations
 
 All the integration examples below assume you have the [configuration file](#configuration-file) created at the root of your application. Whenever you import the `dotalias` package, it automatically reads the closest [configuration](#configuration) and returns the necessary bindings for the integration with other tools.
@@ -190,7 +201,7 @@ When deciding on the optimal configuration format, I've researched the path alia
 | --------------- | ---------- | --------------- | --------------- | ---- | ------ |
 | Exact matches   | ✅         | ✅              | ✅              | ✅   | ✅     |
 | Nested paths    | ✅         | ✅              | ✅              | ✅   | ✅     |
-| Fallbacks       | ✅         | ✅              | ❌ <sup>1</sup> | ✅   | TBA    |
+| Fallbacks       | ✅         | ✅              | ❌ <sup>1</sup> | ✅   | ✅     |
 | RegExp          | ❌         | ❌ <sup>2</sup> | ✅              | ✅   | TBA    |
 | Custom resolver | ❌         | ❌              | ✅              | ❌   | TBA    |
 

--- a/alias.config.js
+++ b/alias.config.js
@@ -1,4 +1,8 @@
 module.exports = {
   'exact-file': './test/fixtures/exact.js',
   'nested-dir/*': './test/fixtures/dir/*',
+  'utils/*': [
+    './test/fixtures/fallback/utils/*',
+    './test/fixtures/fallback/src/utils/*',
+  ],
 }

--- a/src/converters/rollup/createCustomResolver.ts
+++ b/src/converters/rollup/createCustomResolver.ts
@@ -1,0 +1,56 @@
+import {
+  injectPositionals,
+  normalizeWildcardString,
+  replaceWildcardWithPositionals,
+} from '../../utils/strings'
+import { FallbackAlias } from './getFallbackAlias'
+
+export type CustomResolver = (
+  importeeId: string,
+  importerId: string
+) => string | Promise<string>
+
+export function createCustomResolver(alias: FallbackAlias): CustomResolver {
+  const normalizedAlias: FallbackAlias = alias.map(
+    ([moduleName, modulePaths]) => {
+      return [normalizeWildcardString(moduleName), modulePaths]
+    }
+  )
+
+  return async function customResolver(importeeId, importerId) {
+    const matchingAlias = normalizedAlias.find(([moduleName]) => {
+      return new RegExp(moduleName).test(importeeId)
+    })
+
+    const resolve = (modulePath: string) => {
+      return this.resolve(modulePath, importerId, { skipSelf: true })
+    }
+
+    // If the imported module doesn't match any of the alias,
+    // resolve the path according to its "replacement" value.
+    if (!matchingAlias) {
+      return resolve(importeeId).then((resolved) => {
+        return resolved ? resolved : { id: importeeId }
+      })
+    }
+
+    const [moduleName, modulePaths] = matchingAlias
+    const [, ...positionals] = importeeId.match(moduleName)
+
+    const normalizedPaths = modulePaths
+      .map(replaceWildcardWithPositionals)
+      .map((modulePath) => {
+        return injectPositionals(modulePath, positionals)
+      })
+
+    for (const relativeFilePath of normalizedPaths) {
+      const result = await this.resolve(relativeFilePath)
+
+      if (result) {
+        return result
+      }
+    }
+
+    return importeeId
+  }
+}

--- a/src/converters/rollup/getFallbackAlias.ts
+++ b/src/converters/rollup/getFallbackAlias.ts
@@ -1,0 +1,10 @@
+import { AliasConfig } from '../../glossary'
+
+export type FallbackAlias = [string, string[]][]
+
+export function getFallbackAlias(config: AliasConfig): FallbackAlias {
+  // @ts-ignore
+  return Object.entries(config).filter(([, modulePath]) => {
+    return Array.isArray(modulePath)
+  })
+}

--- a/src/converters/rollup/toRollup.test.ts
+++ b/src/converters/rollup/toRollup.test.ts
@@ -1,9 +1,4 @@
-import * as path from 'path'
 import { toRollup } from './toRollup'
-
-function fromProcess(chunk: string) {
-  return path.resolve(process.cwd(), chunk)
-}
 
 it('handles exact module name mapping', () => {
   expect(
@@ -33,4 +28,24 @@ it('transforms wildcards to RegExp groups', () => {
       },
     ],
   })
+})
+
+it('uses custom resolver for fallback module paths', () => {
+  const config = toRollup({
+    exact: 'src/exact.js',
+    'utils/*': ['a/*', 'b/*'] as any as string,
+  })
+
+  expect(config).toHaveProperty('entries', [
+    {
+      find: 'exact',
+      replacement: 'src/exact.js',
+    },
+    {
+      find: /^utils\/(.*)$/,
+      replacement: 'utils/$1',
+    },
+  ])
+  expect(config).toHaveProperty('customResolver')
+  expect(config.customResolver).toBeInstanceOf(Function)
 })

--- a/src/converters/toJestConfig.test.ts
+++ b/src/converters/toJestConfig.test.ts
@@ -45,3 +45,15 @@ it('transforms wildcards to RegExp groups', () => {
     },
   })
 })
+
+it('respects fallback module paths', () => {
+  expect(
+    toJestConfig({
+      'utils/*': ['a/*', 'b/*'] as any as string,
+    })
+  ).toEqual({
+    moduleNameMapper: {
+      '^utils/(.*)$': ['a/$1', 'b/$1'],
+    },
+  })
+})

--- a/src/converters/toJestConfig.ts
+++ b/src/converters/toJestConfig.ts
@@ -38,9 +38,11 @@ const transformWildcards: Reducer<AliasConfig> = (
   [moduleName, modulePath]
 ) => {
   const transformedModuleName = replace(/\*/g, () => '(.*)')(moduleName)
-  const transformedModulePath = replaceWildcardWithPositionals(modulePath)
+  const transformedModulePath = Array.isArray(modulePath)
+    ? modulePath.map(replaceWildcardWithPositionals)
+    : replaceWildcardWithPositionals(modulePath)
 
-  config[transformedModuleName] = transformedModulePath
+  config[transformedModuleName] = transformedModulePath as string
   return config
 }
 

--- a/src/converters/toTypeScript.ts
+++ b/src/converters/toTypeScript.ts
@@ -3,7 +3,7 @@ import { compose } from '../utils/compose'
 
 const wrapPathsInArray = (config: AliasConfig) => {
   return Object.entries(config).reduce((config, [moduleName, modulePath]) => {
-    config[moduleName] = [modulePath]
+    config[moduleName] = [].concat(modulePath)
 
     return config
   }, {})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { cosmiconfigSync } from 'cosmiconfig'
 import { toJestConfig } from './converters/toJestConfig'
-import { toRollup } from './converters/toRollup'
+import { toRollup } from './converters/rollup/toRollup'
 import { toTypeScript } from './converters/toTypeScript'
 import { DotaliasWebpackPlugin } from './webpack/DotaliasWebpackPlugin'
 

--- a/src/utils/strings.test.ts
+++ b/src/utils/strings.test.ts
@@ -4,7 +4,9 @@ import {
   prepend,
   startsWith,
   replace,
+  normalizeWildcardString,
   replaceWildcardWithPositionals,
+  injectPositionals,
 } from './strings'
 
 it('prepend()', () => {
@@ -36,9 +38,23 @@ it('replace()', () => {
   )
 })
 
+it('normalizeWildcardString', () => {
+  expect(normalizeWildcardString('utils/')).toEqual('^utils/$')
+  expect(normalizeWildcardString('utils/*')).toEqual('^utils/(.*)$')
+})
+
 it('replaceWildcardWithPositionals()', () => {
+  expect(replaceWildcardWithPositionals('/src/')).toEqual('/src/')
   expect(replaceWildcardWithPositionals('/src/*')).toEqual('/src/$1')
   expect(replaceWildcardWithPositionals('/src/*/images/*')).toEqual(
     '/src/$1/images/$2'
   )
+})
+
+it('injectPositionals', () => {
+  expect(injectPositionals('utils/', ['internal'])).toEqual('utils/')
+  expect(injectPositionals('utils/$1', ['internal'])).toEqual('utils/internal')
+  expect(
+    injectPositionals('utils/$1/nested/$2', ['internal', 'addNumbers'])
+  ).toEqual('utils/internal/nested/addNumbers')
 })

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,3 +1,5 @@
+import { compose } from './compose'
+
 export function prepend(prefix: string) {
   return (source: string) => prefix + source
 }
@@ -27,10 +29,28 @@ export function replace(
   }
 }
 
+export function normalizeWildcardString(source: string): string {
+  return compose(
+    prepend('^'),
+    append('$'),
+    replace(/\*/g, () => '(.*)')
+  )(source)
+}
+
 export function replaceWildcardWithPositionals(source: string): string {
   let wildcardCount = 0
   return source.replace(/\*/g, () => {
     wildcardCount++
     return `$${wildcardCount}`
+  })
+}
+
+export function injectPositionals(
+  source: string,
+  positionals: string[]
+): string {
+  return source.replace(/\$(\d)/g, (_, group) => {
+    const positionalIndex = parseInt(group, 10) - 1
+    return positionals[positionalIndex]
   })
 }

--- a/test/fixtures/fallback/src/utils/utilOne.js
+++ b/test/fixtures/fallback/src/utils/utilOne.js
@@ -1,0 +1,1 @@
+module.exports = 'fallback-src-utils-one'

--- a/test/fixtures/fallback/src/utils/utilTwo.js
+++ b/test/fixtures/fallback/src/utils/utilTwo.js
@@ -1,0 +1,1 @@
+module.exports = 'fallback-src-utils-two'

--- a/test/fixtures/fallback/utils/utilOne.js
+++ b/test/fixtures/fallback/utils/utilOne.js
@@ -1,0 +1,1 @@
+module.exports = 'fallback-utils-one'

--- a/test/jest/alias.config.js
+++ b/test/jest/alias.config.js
@@ -2,4 +2,8 @@ module.exports = {
   'exact-file': '../fixtures/exact.js',
   'exact-dir': '../fixtures/dir',
   'nested-dir/*': '../fixtures/dir/*',
+  'utils/*': [
+    '../fixtures/fallback/utils/*',
+    '../fixtures/fallback/src/utils/*',
+  ],
 }

--- a/test/jest/jest.fallback.example.js
+++ b/test/jest/jest.fallback.example.js
@@ -1,0 +1,10 @@
+const utilOne = require('utils/utilOne')
+const utilTwo = require('utils/utilTwo')
+
+it('resolves the first match in the fallback paths', () => {
+  expect(utilOne).toEqual('fallback-utils-one')
+})
+
+it('resolves subsequent match in the fallback paths', () => {
+  expect(utilTwo).toEqual('fallback-src-utils-two')
+})

--- a/test/jest/jest.fallback.test.ts
+++ b/test/jest/jest.fallback.test.ts
@@ -1,0 +1,8 @@
+import { exec } from 'child_process'
+
+it('supports fallback module paths', (done) => {
+  exec('jest jest.fallback.example.js', { cwd: __dirname }, (error) => {
+    expect(error).toBeNull()
+    done()
+  })
+})

--- a/test/rollup/alias.config.js
+++ b/test/rollup/alias.config.js
@@ -1,4 +1,8 @@
 module.exports = {
   'exact-file': '../fixtures/exact.js',
   'nested-dir/*': '../fixtures/dir/*',
+  'utils/*': [
+    '../fixtures/fallback/utils/*',
+    '../fixtures/fallback/src/utils/*',
+  ],
 }

--- a/test/rollup/index.js
+++ b/test/rollup/index.js
@@ -1,7 +1,11 @@
 const exact = require('exact-file')
 const one = require('nested-dir/one')
+const utilOne = require('utils/utilOne')
+const utilTwo = require('utils/utilTwo')
 
 module.exports = {
   exact,
   one,
+  utilOne,
+  utilTwo,
 }

--- a/test/rollup/rollup.test.ts
+++ b/test/rollup/rollup.test.ts
@@ -22,4 +22,6 @@ it('supports rollup module alias with "@rollup/plugin-alias"', () => {
   // Expect Rollup to resolve imported modules in-place.
   expect(output).toContain(`var exact = 'exact'`)
   expect(output).toContain(`var one = 'dir-one'`)
+  expect(output).toContain(`var utilOne = 'fallback-utils-one`)
+  expect(output).toContain(`var utilTwo = 'fallback-src-utils-two`)
 })

--- a/test/typescript/alias.config.js
+++ b/test/typescript/alias.config.js
@@ -1,4 +1,8 @@
 module.exports = {
   'exact-file': '../fixtures/exact.js',
   'nested-dir/*': '../fixtures/dir/*',
+  'utils/*': [
+    '../fixtures/fallback/utils/*',
+    '../fixtures/fallback/src/utils/*',
+  ],
 }

--- a/test/typescript/index.ts
+++ b/test/typescript/index.ts
@@ -1,4 +1,6 @@
 import exact from 'exact-file'
 import one from 'nested-dir/one'
+import utilOne from 'utils/utilOne'
+import utilTwo from 'utils/utilTwo'
 
-console.log({ exact, one })
+console.log({ exact, one, utilOne, utilTwo })

--- a/test/webpack/index.js
+++ b/test/webpack/index.js
@@ -1,4 +1,6 @@
 import exact from 'exact-file'
 import one from 'nested-dir/one'
+import utilOne from 'utils/utilOne'
+import utilTwo from 'utils/utilTwo'
 
-export { exact, one }
+export { exact, one, utilOne, utilTwo }

--- a/test/webpack/webpack.test.ts
+++ b/test/webpack/webpack.test.ts
@@ -1,5 +1,6 @@
 import { createFsFromVolume, Volume } from 'memfs'
 import { webpack } from 'webpack'
+
 const webpackConfig = require('./webpack.config')
 
 it('supports webpack module alias', async () => {


### PR DESCRIPTION
## GitHub 

- Closes #3 

## Changes

- Adds support for the fallback paths.
- Adds custom `@rollup/plugin-alias` resolver function.
- Modifies the `DotaliasWebpackPlugin` to support a list of module paths. 
- Adds relevant tests. 