### PR TITLE
fix: set correct node executable for the cli

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 import * as fs from 'fs'
 import * as path from 'path'
 import * as yargs from 'yargs'


### PR DESCRIPTION
The CLI is not usable due to the wrong Node.js executable path.